### PR TITLE
Changed passport extension to passport identifier

### DIFF
--- a/DSTU2.py
+++ b/DSTU2.py
@@ -12,14 +12,18 @@ from fhir.resources.DSTU2.codeableconcept import CodeableConcept
 from fhir.resources.DSTU2.coding import Coding
 from fhir.resources.DSTU2.extension import Extension
 from fhir.resources.DSTU2.humanname import HumanName
+from fhir.resources.DSTU2.identifier import Identifier
 from fhir.resources.DSTU2.fhirreference import FHIRReference
 from fhir.resources.DSTU2.fhirdate import FHIRDate
 from fhir.resources.DSTU2.practitioner import Practitioner
 from fhir.resources.DSTU2.organization import Organization
 from fhir.resources.DSTU2.diagnosticreport import DiagnosticReport
+from fhir.resources.DSTU2.period import Period
 
 SUBJECT_INFO_EXTENSION_URL = "http://commonpass.org/fhir/StructureDefinition/subject-info"
 SUBJECT_INFO_NAME_EXTENSION_URL = "http://commonpass.org/fhir/StructureDefinition/subject-name-info"
+
+SUBJECT_PASSPORT_IDENTIFIER_EXTENSION_URL = "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info"
 
 SUBJECT_INFO_PASSPORT_EXTENSION_URL = "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
 SUBJECT_INFO_PASSPORT_COUNTRY_EXTENSION_URL = "country"
@@ -44,43 +48,89 @@ TEST_MANUFACTURER_MODEL_CODE = "TBD"
 TEST_IDENTIFIER_EXTENSION_URL = "http://commonpass.org/fhir/StructureDefinition/test-identifier"
 TEST_IDENTIFIER_EXTENSION_VALUE = "0123456789"
 
-def create_passport_info_extension(passport_country, passport_number, passport_expiration_date):
+IDENTIFIER_CODE_SYSTEM = "http://terminology.hl7.org/CodeSystem/v2-0203"
+IDENTIFIER_PASSPORT_CODE = "PPN"
+IDENTIFIER_USE_OFFICIAL = "official"
 
-    passport_info_country_extension = Extension()
-    passport_info_country_extension.url = SUBJECT_INFO_PASSPORT_COUNTRY_EXTENSION_URL
-    passport_info_country_extension.valueString = passport_country
+# def create_passport_info_extension(passport_country, passport_number, passport_expiration_date):
 
-    passport_info_number_extension = Extension()
-    passport_info_number_extension.url = SUBJECT_INFO_PASSPORT_NUMBER_EXTENSION_URL
-    passport_info_number_extension.valueString = passport_number
+#     passport_info_country_extension = Extension()
+#     passport_info_country_extension.url = SUBJECT_INFO_PASSPORT_COUNTRY_EXTENSION_URL
+#     passport_info_country_extension.valueString = passport_country
 
-    passport_info_expiration_extension = Extension()
-    passport_info_expiration_extension.url = SUBJECT_INFO_PASSPORT_EXPIRATION_EXTENSION_URL
+#     passport_info_number_extension = Extension()
+#     passport_info_number_extension.url = SUBJECT_INFO_PASSPORT_NUMBER_EXTENSION_URL
+#     passport_info_number_extension.valueString = passport_number
+
+#     passport_info_expiration_extension = Extension()
+#     passport_info_expiration_extension.url = SUBJECT_INFO_PASSPORT_EXPIRATION_EXTENSION_URL
+#     expiration_date = FHIRDate()
+#     expiration_date.date = passport_expiration_date
+#     passport_info_expiration_extension.valueDate = expiration_date
+
+#     passport_extension = Extension()
+#     passport_extension.url = SUBJECT_INFO_PASSPORT_EXTENSION_URL
+#     passport_extension.extension = [
+#         passport_info_country_extension,
+#         passport_info_number_extension,
+#         passport_info_expiration_extension
+#     ]
+
+#     return passport_extension
+
+def create_passport_identifier(passport_country, passport_number, passport_expiration_date):
+
+    identifier = Identifier()
+    identifier.value = passport_number
+
+    assigner = FHIRReference()
+    assigner.display = passport_country
+    identifier.assigner = assigner
+
+    period = Period()
     expiration_date = FHIRDate()
     expiration_date.date = passport_expiration_date
-    passport_info_expiration_extension.valueDate = expiration_date
+    period.end = expiration_date
+    identifier.period = period
 
-    passport_extension = Extension()
-    passport_extension.url = SUBJECT_INFO_PASSPORT_EXTENSION_URL
-    passport_extension.extension = [
-        passport_info_country_extension,
-        passport_info_number_extension,
-        passport_info_expiration_extension
-    ]
+    coding = Coding()
+    coding.system = IDENTIFIER_CODE_SYSTEM
+    coding.code = IDENTIFIER_PASSPORT_CODE
+    coding.display = "Passport Number"
+    codable_concept = CodeableConcept()
+    codable_concept.coding = [coding]
 
-    return passport_extension
+    identifier.type = codable_concept
 
-def get_passport_info_extension(patient):
-    for extension in patient.extension:
-        if extension.url == SUBJECT_INFO_PASSPORT_EXTENSION_URL:
-            return extension
+    return identifier
+
+def get_passport_identifier(patient):
+    for identifier in patient.identifier:
+        if identifier.type != None and identifier.type.coding != None:
+            for coding in identifier.type.coding:
+                if coding.system == IDENTIFIER_CODE_SYSTEM and coding.code == IDENTIFIER_PASSPORT_CODE:
+                    return identifier
 
     return None
+
+# def get_passport_info_extension(patient):
+#     for extension in patient.extension:
+#         if extension.url == SUBJECT_INFO_PASSPORT_EXTENSION_URL:
+#             return extension
+
+#     return None
 
 def create_subject_name_extension(human_name):
     extension = Extension()
     extension.url = SUBJECT_INFO_NAME_EXTENSION_URL
     extension.valueHumanName = human_name
+
+    return extension
+
+def create_subject_passport_extension(identifier):
+    extension = Extension()
+    extension.url = SUBJECT_PASSPORT_IDENTIFIER_EXTENSION_URL
+    extension.valueIdentifier = identifier
 
     return extension
 
@@ -90,9 +140,14 @@ def create_subject_info_extension(patient):
     extension = Extension()
     extension.url = SUBJECT_INFO_EXTENSION_URL
     extension.extension = [
-        create_subject_name_extension(patient.name[0]),
-        get_passport_info_extension(patient)
+        create_subject_name_extension(patient.name[0])
     ]
+
+    passport_identifier = get_passport_identifier(patient)
+    if passport_identifier != None:
+        extension.extension = extension.extension + [
+            create_subject_passport_extension(passport_identifier)
+        ]
 
     return extension
     
@@ -103,9 +158,12 @@ def create_patient(given_name, family_name, passport_number, passport_country, p
     name.given = [given_name]
     patient.name = [name]
 
-    passport_extension = create_passport_info_extension(passport_country, passport_number, passport_expiration_date)
+    passport_identifier = create_passport_identifier(passport_country, passport_number, passport_expiration_date)
+    patient.identifier = [passport_identifier]
 
-    patient.extension = [passport_extension]
+    # passport_extension = create_passport_info_extension(passport_country, passport_number, passport_expiration_date)
+
+    # patient.extension = [passport_extension]
 
     return patient
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# CommonPass Sample Resource Generator 
+To get started, first clone the repo:
+
+```
+git clone https://github.com/the-commons-project/commonpass_sample_resources.git
+```
+
+## Initial setup
+The scripts depend on the Python modules defined in `requirements.txt`, so you'll need to make sure that they are installed. The easiest way to do so would be to create and activate a virtual environment. You can use the following commands to do so:
+
+```
+python -m venv myenv
+source myenv/bin/activate
+```
+
+Then, you can install the dependencies using the following command:
+
+```
+pip install -r requirements.txt
+```
+
+## Running the scripts
+If you've set up a virtual environment, you will need to make sure it's active (e.g., `source myenv/bin/activate`). You can run the script using the following command:
+
+```
+python DSTU2.py smart_it_sandbox.json
+```
+
+`DSTU2.py` takes a config file as a parameter. If you specify `smart_it_sandbox.json` as the config file parameter, it will generate resources based on the options in the config file and store them in the SMART IT Sandbox (see the `unprotected_base_url` option in the config file). The script with output the patient ID of the newly created patient. You can use that patient ID when authorizing a SMART app in order to get access to the newly created resources. 
+
+
+

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report.json
@@ -1,7 +1,7 @@
 {
-    "id": "153586",
+    "id": "565755",
     "meta": {
-        "lastUpdated": "2020-09-10T22:45:20.913+00:00",
+        "lastUpdated": "2020-09-15T22:01:10.363-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -11,10 +11,6 @@
             "resourceType": "Organization"
         }
     ],
-    "text": {
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\"> SARS-COV-2, NAA </div><table class=\"hapiPropertyTable\"><tbody><tr><td>Status</td><td>final</td></tr><tr><td>Issued</td><td> 15 July 2020 05:10:45 </td></tr></tbody></table></div>",
-        "status": "generated"
-    },
     "category": {
         "coding": [
             {
@@ -40,10 +36,10 @@
     },
     "result": [
         {
-            "reference": "Observation/153584"
+            "reference": "Observation/565753"
         },
         {
-            "reference": "Observation/153585"
+            "reference": "Observation/565754"
         }
     ],
     "status": "final",
@@ -63,28 +59,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "resourceType": "DiagnosticReport"
 }

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report.json
@@ -1,7 +1,7 @@
 {
-    "id": "565755",
+    "id": "565903",
     "meta": {
-        "lastUpdated": "2020-09-15T22:01:10.363-04:00",
+        "lastUpdated": "2020-09-18T11:02:02.994-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -36,10 +36,10 @@
     },
     "result": [
         {
-            "reference": "Observation/565753"
+            "reference": "Observation/565901"
         },
         {
-            "reference": "Observation/565754"
+            "reference": "Observation/565902"
         }
     ],
     "status": "final",
@@ -59,7 +59,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -78,13 +78,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "resourceType": "DiagnosticReport"
 }

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report_pre_upload.json
@@ -31,10 +31,10 @@
     },
     "result": [
         {
-            "reference": "Observation/153584"
+            "reference": "Observation/565753"
         },
         {
-            "reference": "Observation/153585"
+            "reference": "Observation/565754"
         }
     ],
     "status": "final",
@@ -54,28 +54,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "resourceType": "DiagnosticReport"
 }

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/diagnostic_report_pre_upload.json
@@ -31,10 +31,10 @@
     },
     "result": [
         {
-            "reference": "Observation/565753"
+            "reference": "Observation/565901"
         },
         {
-            "reference": "Observation/565754"
+            "reference": "Observation/565902"
         }
     ],
     "status": "final",
@@ -54,7 +54,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -73,13 +73,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "resourceType": "DiagnosticReport"
 }

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0.json
@@ -1,7 +1,7 @@
 {
-    "id": "565753",
+    "id": "565901",
     "meta": {
-        "lastUpdated": "2020-09-15T22:01:09.802-04:00",
+        "lastUpdated": "2020-09-18T11:02:02.433-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -91,7 +91,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -110,13 +110,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "valueString": "Negative",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0.json
@@ -1,7 +1,7 @@
 {
-    "id": "153584",
+    "id": "565753",
     "meta": {
-        "lastUpdated": "2020-09-10T22:45:20.772+00:00",
+        "lastUpdated": "2020-09-15T22:01:09.802-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -91,28 +91,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "valueString": "Negative",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0_pre_upload.json
@@ -86,28 +86,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "valueString": "Negative",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_0_pre_upload.json
@@ -86,7 +86,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -105,13 +105,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "valueString": "Negative",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1.json
@@ -1,7 +1,7 @@
 {
-    "id": "153585",
+    "id": "565754",
     "meta": {
-        "lastUpdated": "2020-09-10T22:45:20.845+00:00",
+        "lastUpdated": "2020-09-15T22:01:10.080-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -91,28 +91,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "valueString": "Indeterminate",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1.json
@@ -1,7 +1,7 @@
 {
-    "id": "565754",
+    "id": "565902",
     "meta": {
-        "lastUpdated": "2020-09-15T22:01:10.080-04:00",
+        "lastUpdated": "2020-09-18T11:02:02.713-04:00",
         "versionId": "1"
     },
     "contained": [
@@ -91,7 +91,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -110,13 +110,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "valueString": "Indeterminate",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1_pre_upload.json
@@ -86,7 +86,7 @@
                         }
                     },
                     {
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
                         "valueIdentifier": {
                             "assigner": {
                                 "display": "United States of America"
@@ -105,13 +105,34 @@
                             },
                             "value": "12345678-90"
                         }
+                    },
+                    {
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "UK"
+                            },
+                            "period": {
+                                "end": "2023-01-14"
+                            },
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "9872349875987"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/565752"
+        "reference": "Patient/565900"
     },
     "valueString": "Indeterminate",
     "resourceType": "Observation"

--- a/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1_pre_upload.json
+++ b/dstu2/dr_with_referenced_labs_with_referenced_patient/lab_result_1_pre_upload.json
@@ -86,28 +86,32 @@
                         }
                     },
                     {
-                        "extension": [
-                            {
-                                "url": "country",
-                                "valueString": "United States of America"
+                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-identifier-info",
+                        "valueIdentifier": {
+                            "assigner": {
+                                "display": "United States of America"
                             },
-                            {
-                                "url": "number",
-                                "valueString": "12345678-90"
+                            "period": {
+                                "end": "2024-12-04"
                             },
-                            {
-                                "url": "expiration",
-                                "valueDate": "2024-12-04"
-                            }
-                        ],
-                        "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "PPN",
+                                        "display": "Passport Number",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                                    }
+                                ]
+                            },
+                            "value": "12345678-90"
+                        }
                     }
                 ],
                 "url": "http://commonpass.org/fhir/StructureDefinition/subject-info"
             }
         ],
         "display": "Lab A Patient",
-        "reference": "Patient/153583"
+        "reference": "Patient/565752"
     },
     "valueString": "Indeterminate",
     "resourceType": "Observation"

--- a/dstu2/patient.json
+++ b/dstu2/patient.json
@@ -1,32 +1,29 @@
 {
-    "id": "153583",
+    "id": "565752",
     "meta": {
-        "lastUpdated": "2020-09-10T22:45:20.629+00:00",
+        "lastUpdated": "2020-09-15T22:01:09.521-04:00",
         "versionId": "1"
     },
-    "extension": [
+    "identifier": [
         {
-            "extension": [
-                {
-                    "url": "country",
-                    "valueString": "United States of America"
-                },
-                {
-                    "url": "number",
-                    "valueString": "12345678-90"
-                },
-                {
-                    "url": "expiration",
-                    "valueDate": "2024-12-04"
-                }
-            ],
-            "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+            "assigner": {
+                "display": "United States of America"
+            },
+            "period": {
+                "end": "2024-12-04"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "code": "PPN",
+                        "display": "Passport Number",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                    }
+                ]
+            },
+            "value": "12345678-90"
         }
     ],
-    "text": {
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\">Lab A <b>PATIENT </b></div><table class=\"hapiPropertyTable\"><tbody></tbody></table></div>",
-        "status": "generated"
-    },
     "name": [
         {
             "family": [

--- a/dstu2/patient.json
+++ b/dstu2/patient.json
@@ -1,7 +1,7 @@
 {
-    "id": "565752",
+    "id": "565900",
     "meta": {
-        "lastUpdated": "2020-09-15T22:01:09.521-04:00",
+        "lastUpdated": "2020-09-18T11:02:02.158-04:00",
         "versionId": "1"
     },
     "identifier": [
@@ -22,6 +22,24 @@
                 ]
             },
             "value": "12345678-90"
+        },
+        {
+            "assigner": {
+                "display": "UK"
+            },
+            "period": {
+                "end": "2023-01-14"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "code": "PPN",
+                        "display": "Passport Number",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                    }
+                ]
+            },
+            "value": "9872349875987"
         }
     ],
     "name": [

--- a/dstu2/patient_pre_upload.json
+++ b/dstu2/patient_pre_upload.json
@@ -17,6 +17,24 @@
                 ]
             },
             "value": "12345678-90"
+        },
+        {
+            "assigner": {
+                "display": "UK"
+            },
+            "period": {
+                "end": "2023-01-14"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "code": "PPN",
+                        "display": "Passport Number",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                    }
+                ]
+            },
+            "value": "9872349875987"
         }
     ],
     "name": [

--- a/dstu2/patient_pre_upload.json
+++ b/dstu2/patient_pre_upload.json
@@ -1,21 +1,22 @@
 {
-    "extension": [
+    "identifier": [
         {
-            "extension": [
-                {
-                    "url": "country",
-                    "valueString": "United States of America"
-                },
-                {
-                    "url": "number",
-                    "valueString": "12345678-90"
-                },
-                {
-                    "url": "expiration",
-                    "valueDate": "2024-12-04"
-                }
-            ],
-            "url": "http://commonpass.org/fhir/StructureDefinition/subject-passport-info"
+            "assigner": {
+                "display": "United States of America"
+            },
+            "period": {
+                "end": "2024-12-04"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "code": "PPN",
+                        "display": "Passport Number",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+                    }
+                ]
+            },
+            "value": "12345678-90"
         }
     ],
     "name": [

--- a/smart_it_sandbox.json
+++ b/smart_it_sandbox.json
@@ -1,0 +1,44 @@
+{
+    "unprotected_base_url": " https://r2.smarthealthit.org",
+    "output_directory_name": "dstu2",
+    "patient": {
+        "given_name": "Lab A",
+        "family_name": "Patient",
+        "passport_number": "12345678-90",
+        "passport_country": "United States of America",
+        "passport_expiration": "2024-12-04"
+    },
+    "organization": {
+        "id": "8932748723984",
+        "name": "Test Facility A"
+    },
+    "lab_tech": {
+        "id": "23980293840932",
+        "given_name": "Lab",
+        "family_name": "Tech"
+    },
+    "diagnostic_report": {
+        "code_code": "94500-6",
+        "code_display": "SARS-COV-2, NAA",
+        "effective": "2020-07-14T23:10:45",
+        "issued": "2020-07-14T23:10:45"
+    },
+    "lab_results": [
+        {
+            "code_code": "94564-2",
+            "code_display": "SARS-CoV-2 Antibody, IgM",
+            "valueString": "Negative",
+            "interpretation": "N",
+            "effective": "2020-07-14T23:10:45",
+            "issued": "2020-07-14T23:10:45"
+        },
+        {
+            "code_code": "94500-6",
+            "code_display": "SARS-COV-2, NAA",
+            "valueString": "Indeterminate",
+            "interpretation": "N",
+            "effective": "2020-07-14T23:10:45",
+            "issued": "2020-07-14T23:10:45"
+        }
+    ]
+}

--- a/smart_it_sandbox.json
+++ b/smart_it_sandbox.json
@@ -4,9 +4,18 @@
     "patient": {
         "given_name": "Lab A",
         "family_name": "Patient",
-        "passport_number": "12345678-90",
-        "passport_country": "United States of America",
-        "passport_expiration": "2024-12-04"
+        "passports": [
+            {
+                "passport_number": "12345678-90",
+                "passport_country": "United States of America",
+                "passport_expiration": "2024-12-04"
+            },
+            {
+                "passport_number": "9872349875987",
+                "passport_country": "UK",
+                "passport_expiration": "2023-01-14"
+            }
+        ]
     },
     "organization": {
         "id": "8932748723984",


### PR DESCRIPTION
Per feedback from @JulietteHP, changed the passport extension to a passport identifier on the Patient resource